### PR TITLE
#8 이론 위주의 역제어, 의존성주입

### DIFF
--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
+import { PostsService } from './posts.service';
 
 @Module({
   controllers: [PostsController],
-  providers: [PostsService]
+  providers: [PostsService], //@Injectable을 위한 프로바이더 -> 주입
 })
 export class PostsModule {}


### PR DESCRIPTION
```
class A {
	constructor(instance: B)
}
```
```
class B {

}

```
외부에서 클래스 A가 생성될 때 무조건 클래스 B에 해당되는 인스턴스를 넣어 주도록 정의를한다. 
-> 그렇지 않으면 constructor를 실행할 수 없음. -> 역제어

IOC 컨테이너에서 자동 생성, IOC 컨테이너에서 자동으로 인스턴스화를 함.-> 클래스를 그대로 모듈에 등록.

module -> controllers) nestJS에서 컨트롤러로 등록
module -> providers) 컨트롤러에서 주입을 하는 값들을 전부 다 프로바이더에 등록해야 인식을 한다.
@Injectable -> 주입할수 있음

appModule은 main.ts에서 실행시킴.
각 모듈은 앱모듈에 등록되고, 앱모듈은 main.ts에서 실행된다.